### PR TITLE
221006 모임/후기 수정 시 bug fix

### DIFF
--- a/src/main/java/com/innovation/backend/controller/MeetingController.java
+++ b/src/main/java/com/innovation/backend/controller/MeetingController.java
@@ -50,7 +50,6 @@ public class MeetingController {
   //모임 삭제
   @DeleteMapping("/meeting/{meetingId}")
   public ResponseDto<String> deleteMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable("meetingId") Long meetingId) {
-      Member member = userDetails.getMember();
       meetingService.deleteMeeting(meetingId, userDetails);
     return ResponseDto.success("모임을 삭제하였습니다.");
 

--- a/src/main/java/com/innovation/backend/service/MeetingService.java
+++ b/src/main/java/com/innovation/backend/service/MeetingService.java
@@ -169,13 +169,16 @@ public class MeetingService {
                     }
                 }
             }else {
-                try{
-                    meetingImage = s3Upload.uploadFiles(image, "images");
-                }catch (IOException e){
-                    log.error(e.getMessage());
+                if (image == null || image.isEmpty()) {
+                    meetingImage = null;
+                } else if (!image.isEmpty()) {
+                    try {
+                        meetingImage = s3Upload.uploadFiles(image, "images");
+                    } catch (IOException e) {
+                        log.error(e.getMessage());
+                    }
                 }
             }
-
             // 수정
             meeting.update(requestDto,meetingImage);
 
@@ -297,9 +300,9 @@ public class MeetingService {
     public MeetingLikeResponseDto getMeetingLike(UserDetailsImpl userDetails, Long meetingId) {
         boolean meetingLike = false;
         if (userDetails != null) {
-        String userId = userDetails.getUsername();
-        Member member = memberRepository.findByEmail(userId).orElseThrow();
-        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+            String userId = userDetails.getUsername();
+            Member member = memberRepository.findByEmail(userId).orElseThrow();
+            Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
             meetingLike = isMeetingLike(member,meeting);
         }
         return new MeetingLikeResponseDto(meetingLike);

--- a/src/main/java/com/innovation/backend/service/ReviewService.java
+++ b/src/main/java/com/innovation/backend/service/ReviewService.java
@@ -100,11 +100,16 @@ public class ReviewService {
           log.error(e.getMessage());
         }}
     }else{
+      if(image == null || image.isEmpty()){
+        reviewImage = null;
+      }else if (!image.isEmpty()){
         try{
           reviewImage = s3Upload.uploadFiles(image,"reviews");
         }catch (IOException e){
           log.error(e.getMessage());
-        }}
+        }
+      }
+    }
     review.updateReview(requestDto,reviewImage);
     reviewRepository.save(review);
   }


### PR DESCRIPTION
🚨 모임 / 후기 수정 시 
 - 원래 이미지가 null 인 모임/후기 를 똑같이 이미지 null 인 상태로 수정시
 - 그대로 null 값이 아닌 하얀색 이미지가 저장되어 나옴
 - 조건식 추가하여 그대로 null로 나오게 수정