### PR TITLE
221006 모임 참여 기간 아니어도 모임 참여 가능한 bug fix

### DIFF
--- a/src/main/java/com/innovation/backend/entity/Meeting.java
+++ b/src/main/java/com/innovation/backend/entity/Meeting.java
@@ -112,7 +112,11 @@ public class Meeting extends Timestamped{
     this.meetingEndDate = requestDto.getMeetingEndDate();
     this.location = requestDto.getLocation();
     this.limitPeople = requestDto.getLimitPeople();
-    this.meetingStatus = MeetingStatus.CAN_JOIN;
+    if(requestDto.getJoinStartDate().equals(LocalDate.now()) || requestDto.getJoinStartDate().isBefore(LocalDate.now())){
+      this.meetingStatus = MeetingStatus.CAN_JOIN;
+    }else if(requestDto.getJoinStartDate().isAfter(LocalDate.now())){
+      this.meetingStatus = MeetingStatus.READY_FOR_JOIN;
+    }
     this.admin = member;
   }
 

--- a/src/main/java/com/innovation/backend/enums/ErrorCode.java
+++ b/src/main/java/com/innovation/backend/enums/ErrorCode.java
@@ -48,8 +48,10 @@ public enum ErrorCode {
   ALREADY_COMPLETE_JOIN("ALREADY_COMPLETE_JOIN","이미 모집이 완료된 모임입니다."),
   ALREADY_PASS_DEADLINE("ALREADY_PASS_DEADLINE","이미 모집 기한이 지난 모임입니다."),
   ALREADY_COMPLETED_MEETING("ALREADY_COMPLETED_MEETING","이미 모임이 완료된 모임입니다."),
+  READY_FOR_JOIN("READY_FOR_JOIN","아직 참여 준비 중인 모임입니다."),
   CAN_NOT_UPDATE_MEETING ("CAN_NOT_UPDATE_MEETING","참여 인원이 2명 이상시에는 수정이 불가능합니다."),
   CAN_NOT_UPDATE_MEETING2("CAN_NOT_UPDATE_MEETING2","모집 중 상태일 때만 수정이 가능합니다."),
+
   //후기
   NOT_FOUND_REVIEW("NOT_FOUND_REVIEW","후기를 찾을 수 없습니다."),
   ONLY_ONE_REVIEW("ONLY_ONE_REVIEW","후기는 한번만 작성할 수 있습니다."),

--- a/src/main/java/com/innovation/backend/enums/MeetingStatus.java
+++ b/src/main/java/com/innovation/backend/enums/MeetingStatus.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum MeetingStatus {
-
-  CAN_JOIN ("CAN_JOIN","모집 중"),
+  READY_FOR_JOIN("READY_FOR_JOIN","모집 준비 중"),
+  CAN_JOIN("CAN_JOIN","모집 중"),
   COMPLETE_JOIN("COMPLETE_JOIN","모집 완료"),
   PASS_DEADLINE("PASS_DEADLINE","모집 기한이 지난 모임"),
   COMPLETED_MEETING("COMPLETED_MEETING","모임 완료");

--- a/src/main/java/com/innovation/backend/scheduler/MeetingScheduler.java
+++ b/src/main/java/com/innovation/backend/scheduler/MeetingScheduler.java
@@ -34,5 +34,11 @@ public class MeetingScheduler {
         meeting.setMeetingStatus(MeetingStatus.COMPLETED_MEETING);
       }
     }
+
+    for (Meeting meeting : meetingList){
+      if(meeting.getJoinStartDate().equals(LocalDate.now())){
+        meeting.setMeetingStatus(MeetingStatus.CAN_JOIN);
+      }
+    }
   }
 }

--- a/src/main/java/com/innovation/backend/service/CrewService.java
+++ b/src/main/java/com/innovation/backend/service/CrewService.java
@@ -117,6 +117,9 @@ public class CrewService {
     if(meeting.getMeetingStatus() == MeetingStatus.COMPLETED_MEETING){
       throw new CustomErrorException(ErrorCode.ALREADY_COMPLETED_MEETING);
     }
+    if(meeting.getMeetingStatus() == MeetingStatus.READY_FOR_JOIN){
+      throw new CustomErrorException(ErrorCode.READY_FOR_JOIN);
+    }
     if(meeting.getJoinEndDate().isBefore(LocalDate.now())){
       throw new CustomErrorException(ErrorCode.ALREADY_PASS_DEADLINE);
     }


### PR DESCRIPTION
🚨 모임 생성 시에 무조건 CAN_JOIN 으로 참여 기간을 나중으로 해도 CAN_JOIN 으로 상태가 나가 참여 가능 했음
👉 모임 생성 시 참여 기한이 생성 날짜 보다 나중이면 READY_FOR_JOIN 으로 상태가 나감 (생성 날짜와 같으면 그대로 CAN_JOIN)
👉 scheduler를 이용하여 12시 1분에 참여 가능 기한이되면 CAN_JOIN으로 상태 변경 