### PR TITLE
221012 [Fix] Meeting GetByTag Pagination Bug Fix

### DIFF
--- a/src/main/java/com/innovation/backend/domain/Meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/innovation/backend/domain/Meeting/repository/MeetingRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting,Long> {
-  Page<Meeting> findAllByOrderByCreatedAtDesc( Pageable pageable);
+  Page<Meeting> findAllByOrderByCreatedAtDesc(Pageable pageable);
   List<Meeting> findTop4ByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/innovation/backend/domain/Meeting/repository/MeetingTagConnectionRepository.java
+++ b/src/main/java/com/innovation/backend/domain/Meeting/repository/MeetingTagConnectionRepository.java
@@ -2,12 +2,16 @@ package com.innovation.backend.domain.Meeting.repository;
 
 import com.innovation.backend.domain.Meeting.domain.MeetingTagConnection;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface MeetingTagConnectionRepository extends JpaRepository<MeetingTagConnection, Long> {
 
-  @Query(nativeQuery = true, value = "select m.* from meeting_tag_connection as m where tag_id = :tagId")
-  List<MeetingTagConnection> findByTagId(Long tagId);
+  @Query(nativeQuery = true, value = "select m.* from meeting_tag_connection as m where tag_id in (:tagId) limit :offset, :limit")
+  List<MeetingTagConnection> findByTagId(List<Long> tagId, long offset, int limit);
 
+  @Query(nativeQuery = true, value = "select count(*) from meeting_tag_connection as m where tag_id in (:tagId)")
+  Long findByTagIdCount(List<Long> tagId);
 }


### PR DESCRIPTION
👉 태그 별 모임 조회 시 
 - defaultSize = 12 임에도 전체 elements가 모두 뜸
 - last Page 임에도 계속 totalElements 증가함 
 👉 nativeQuery 식을 수정 하여 Elements와 Pageable의 맞는 값을 가져오도록 함. 